### PR TITLE
オブジェクト生成方向の修正

### DIFF
--- a/Unity/Assets/Photon Unity Networking/Demos/MarcoPolo-Tutorial/Monstergame/Resources/Card.prefab
+++ b/Unity/Assets/Photon Unity Networking/Demos/MarcoPolo-Tutorial/Monstergame/Resources/Card.prefab
@@ -2368,7 +2368,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9052cdfe7e3f94fb39f3effd46776856, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Childs: 3
+  Childs: 4
 --- !u!136 &136000011664287740
 CapsuleCollider:
   m_ObjectHideFlags: 1

--- a/Unity/Assets/PhotonScript.unity
+++ b/Unity/Assets/PhotonScript.unity
@@ -37,7 +37,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.45195162, g: 0.50124943, b: 0.5715151, a: 1}
+  m_IndirectSpecularColor: {r: 0.44692492, g: 0.4967869, b: 0.57508546, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -349,6 +349,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 2119278837}
+  - {fileID: 1806530795}
   m_Father: {fileID: 2037021391}
   m_RootOrder: 0
 --- !u!81 &965776187
@@ -915,12 +916,12 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1806530794}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 5}
+  m_LocalPosition: {x: 0, y: -0.70000005, z: 5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
-  m_Father: {fileID: 2037021391}
-  m_RootOrder: 2
+  m_Father: {fileID: 965776186}
+  m_RootOrder: 1
 --- !u!23 &1806530796
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1227,7 +1228,6 @@ Transform:
   m_Children:
   - {fileID: 965776186}
   - {fileID: 979322878}
-  - {fileID: 1806530795}
   m_Father: {fileID: 0}
   m_RootOrder: 3
 --- !u!114 &2037021392


### PR DESCRIPTION
GeneratorをCameraの子オブジェクトにすることでプレイヤーが向いている方向にオブジェクトが出ます。
Cameracontrollerの子オブジェクトだったためにトラッキングが適用されていませんでした。